### PR TITLE
Fix documentation builds

### DIFF
--- a/crates/torsh/src/lib.rs
+++ b/crates/torsh/src/lib.rs
@@ -65,6 +65,7 @@
 // Framework infrastructure - components designed for future use
 #![allow(dead_code)]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![feature(doc_cfg)]
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;


### PR DESCRIPTION
The lack of a feature flag is causing a [build failure](https://docs.rs/crate/torsh/latest/builds/2921195) of the documentation; this PR adds it